### PR TITLE
The origins list is now generated in coffeescript to allow dynamically adding bodies via the console

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,30 +46,6 @@
                   <label class="control-label" for="originSelect">Origin:</label>
                   <div class="controls">
                     <select id="originSelect">
-    									<option>Moho</option>
-    									<option>Eve</option>
-                      <optgroup label="Eve's moons:">
-    										<option>Gilly</option>
-    									</optgroup>
-    									<option selected="true">Kerbin</option>
-    									<optgroup label="Kerbin's moons:">
-    										<option>Mun</option>
-    										<option>Minmus</option>
-    									</optgroup>
-    									<option>Duna</option>
-                      <optgroup label="Duna's moons:">
-    									  <option>Ike</option>
-    									</optgroup>
-    									<option>Dres</option>
-                      <option>Jool</option>
-    									<optgroup label="Jool's moons:">
-    										<option>Laythe</option>
-    										<option>Vall</option>
-    										<option>Tylo</option>
-    										<option>Bop</option>
-    										<option>Pol</option>
-    									</optgroup>
-    									<option>Eeloo</option>
                     </select>
                   </div>
                 </div>

--- a/javascripts/porkchop.js
+++ b/javascripts/porkchop.js
@@ -415,12 +415,12 @@
         }
         group = $('<optgroup>');
         listBody(v, group);
+        elem.append($('<option>').text(k));
         if (group.children().size() > 0) {
-          group.prepend($('<option>').text(k));
-          group.attr('label', k + ' System');
+          group.attr('label', k + '\'s Moons');
           _results.push(elem.append(group));
         } else {
-          _results.push(elem.append($('<option>').text(k)));
+          _results.push(void 0);
         }
       }
       return _results;

--- a/javascripts/porkchop.js
+++ b/javascripts/porkchop.js
@@ -401,10 +401,37 @@
     return $('#longestTimeOfFlight').val(maxDays);
   };
 
+  this.prepareOrigins = function() {
+    var listBody, o;
+    o = $('#originSelect');
+    o.empty();
+    return (listBody = (function(body, elem) {
+      var group, k, v, _ref, _results;
+      _results = [];
+      for (k in CelestialBody) {
+        v = CelestialBody[k];
+        if (!((v != null ? (_ref = v.orbit) != null ? _ref.referenceBody : void 0 : void 0) === body)) {
+          continue;
+        }
+        group = $('<optgroup>');
+        listBody(v, group);
+        if (group.children().size() > 0) {
+          group.prepend($('<option>').text(k));
+          group.attr('label', k + ' System');
+          _results.push(elem.append(group));
+        } else {
+          _results.push(elem.append($('<option>').text(k)));
+        }
+      }
+      return _results;
+    }))(CelestialBody.Kerbol, o);
+  };
+
   $(document).ready(function() {
     canvasContext = $('#porkchopCanvas')[0].getContext('2d');
     plotImageData = canvasContext.createImageData(PLOT_WIDTH, PLOT_HEIGHT);
     prepareCanvas();
+    prepareOrigins();
     $('#porkchopCanvas').mousemove(function(event) {
       var offsetX, offsetY, pointer, x, y, _ref, _ref1;
       if (deltaVs != null) {

--- a/src/porkchop.coffee
+++ b/src/porkchop.coffee
@@ -325,11 +325,27 @@ updateAdvancedControls = ->
   $('#shortestTimeOfFlight').val(minDays)
   $('#longestTimeOfFlight').val(maxDays)
 
+@prepareOrigins = -> #Globalized so bodies can be added in the console
+  o = $('#originSelect')
+  o.empty()
+  (listBody = ( (body, elem) ->
+    for k, v of CelestialBody when v?.orbit?.referenceBody == body
+      group = $('<optgroup>')
+      listBody(v, group)
+      if group.children().size() > 0
+        group.prepend($('<option>').text(k))
+        group.attr('label', k + ' System')
+        elem.append(group)
+      else
+        elem.append($('<option>').text(k))
+  ))(CelestialBody.Kerbol, o)
+
 $(document).ready ->
   canvasContext = $('#porkchopCanvas')[0].getContext('2d')
   plotImageData = canvasContext.createImageData(PLOT_WIDTH, PLOT_HEIGHT)
   
   prepareCanvas()
+  prepareOrigins()
   
   $('#porkchopCanvas').mousemove (event) ->
     if deltaVs?

--- a/src/porkchop.coffee
+++ b/src/porkchop.coffee
@@ -332,12 +332,10 @@ updateAdvancedControls = ->
     for k, v of CelestialBody when v?.orbit?.referenceBody == body
       group = $('<optgroup>')
       listBody(v, group)
+      elem.append($('<option>').text(k))
       if group.children().size() > 0
-        group.prepend($('<option>').text(k))
-        group.attr('label', k + ' System')
+        group.attr('label', k + '\'s Moons')
         elem.append(group)
-      else
-        elem.append($('<option>').text(k))
   ))(CelestialBody.Kerbol, o)
 
 $(document).ready ->


### PR DESCRIPTION
For example, if you were using the Alternis mod and wanted to try the
transfer from Kerbin to Laythe, you'd add new bodies in the console
with this code and use them. Plus now there's potential for a UI for
this.

```
CelestialBody.KerbinAlternis = KerbinAlternis = new CelestialBody(5.2915793e22, 600000, 21600, new Orbit(CelestialBody.Jool, 68506000, 0.02, 0.4, 0, 0, 270 * Math.PI / 180))
CelestialBody.LaytheAlternis = LaytheAlternis = new CelestialBody(2.9397663e22, 500000, 52980.879, new Orbit(CelestialBody.Jool, 27184000, 0, 0, 0, 0, Math.PI))
prepareOrigins()
```
