### PR TITLE
Change url hash to reflect base parameters

### DIFF
--- a/src/missionform.coffee
+++ b/src/missionform.coffee
@@ -82,6 +82,24 @@ class MissionForm
     
     @form.bind 'reset', (event) => setTimeout((=> setOrigin('Kerbin'); setDestination('Duna')), 0)
     @form.submit ((event) => event.preventDefault(); $(@).trigger('submit'))
+        
+    @parseParameters()
+    $(window).on 'hashchange', => @parseParameters()
+  
+  parseParameters: ->
+    params = location.hash.split('/')
+    if params.length > 9
+      @setOrigin(params[1])
+      $('#initialOrbit').val(params[2])
+      @setDestination(params[3])
+      $('#finalOrbit').val(params[4])
+      if (params[5] == 'true') != $('#noInsertionBurnCheckbox').is(':checked')
+        $('#noInsertionBurnCheckbox').click()
+      $('#transferTypeSelect').val(params[6])
+      $(if params[7] == 'true' then '#earthTime' else '#kerbalTime').click()
+      $('#earliestDepartureYear').val(params[8])
+      $('#earliestDepartureDay').val(params[9])
+      @adjustLatestDeparture()
   
   origin: ->
     CelestialBody[$('#originSelect').val()]
@@ -162,7 +180,8 @@ class MissionForm
     else
       initialOrbitalVelocity = origin.circularOrbitVelocity(initialOrbit * 1e3)
         
-    if $('#noInsertionBurnCheckbox').is(":checked")
+    noInsertionBurn = $('#noInsertionBurnCheckbox').is(":checked")
+    if noInsertionBurn
       finalOrbitalVelocity = null
     else if !destination.mass? or +finalOrbit == 0
       finalOrbitalVelocity = 0
@@ -175,6 +194,10 @@ class MissionForm
     
     shortestTimeOfFlight = KerbalTime.fromDuration(0, +$('#shortestTimeOfFlight').val()).t
     yScale = KerbalTime.fromDuration(0, +$('#longestTimeOfFlight').val()).t - shortestTimeOfFlight
+
+    # build url from mission parameters
+    params = [$('#originSelect').val(), initialOrbit, $('#destinationSelect').val(), finalOrbit, noInsertionBurn, transferType, $('#earthTime').is(':checked'), $('#earliestDepartureYear').val(), $('#earliestDepartureDay').val()]
+    location.hash = '#/' + params.join('/')
     
     mission = {
       transferType: transferType


### PR DESCRIPTION
Whenever a user plots a mission the hash part of the url gets updated
with the basic mission parameters. This hash gets parsed when the site
is loaded and whenever the user navigates (for example by using the
browser's back button / clicking on a bookmark).

This is just some functionality that I found useful and I thought others 
might benefit from this as well. 

Just as a heads up, when compiling with CoffeeScript 1.9.2 I had to 
change one line in src/missionform.coffee as seen in this commit: 
4cf8a1e267c4d8dfceca856e5062fc1b1c42e207

I'm a newbie to coffeescript so if I did something wrong / not optimally 
I would love a heads up!
