### PR TITLE
Larger y-axis transfer time range for more eccentric orbits

### DIFF
--- a/javascripts/missionform.js
+++ b/javascripts/missionform.js
@@ -368,12 +368,20 @@
     };
 
     updateAdvancedControls = function() {
-      var departureRange, destination, hohmannTransfer, hohmannTransferTime, maxDays, maxDeparture, minDays, minDeparture, origin, referenceBody, synodicPeriod;
+      var departureRange, destination, destinationApoapsis, destinationPeriapsis, maxDays, maxDeparture, maxHohmannTransferTime, minDays, minDeparture, minHohmannTransferTime, origin, originApopsis, originPeriapsis, referenceBody, synodicPeriod;
       origin = this.origin();
       destination = this.destination();
       referenceBody = origin.orbit.referenceBody;
-      hohmannTransfer = Orbit.fromApoapsisAndPeriapsis(referenceBody, destination.orbit.semiMajorAxis, origin.orbit.semiMajorAxis, 0, 0, 0, 0);
-      hohmannTransferTime = hohmannTransfer.period() / 2;
+      originPeriapsis = origin.orbit.periapsis();
+      originApopsis = origin.orbit.apoapsis();
+      destinationPeriapsis = destination.orbit.periapsis();
+      destinationApoapsis = destination.orbit.apoapsis();
+      if (destinationPeriapsis <= originApopsis && originPeriapsis <= destinationApoapsis) {
+        minHohmannTransferTime = 0;
+      } else {
+        minHohmannTransferTime = Orbit.fromApoapsisAndPeriapsis(referenceBody, destinationPeriapsis, originPeriapsis, 0, 0, 0, 0).period() / 2;
+      }
+      maxHohmannTransferTime = Orbit.fromApoapsisAndPeriapsis(referenceBody, destinationApoapsis, originApopsis, 0, 0, 0, 0).period() / 2;
       synodicPeriod = Math.abs(1 / (1 / destination.orbit.period() - 1 / origin.orbit.period()));
       departureRange = Math.min(2 * synodicPeriod, 2 * origin.orbit.period()) / KerbalTime.secondsPerDay();
       if (departureRange < 0.1) {
@@ -385,8 +393,8 @@
       }
       minDeparture = KerbalTime.fromDate($('#earliestDepartureYear').val(), $('#earliestDepartureDay').val()).t / KerbalTime.secondsPerDay();
       maxDeparture = minDeparture + departureRange;
-      minDays = Math.max(hohmannTransferTime - destination.orbit.period(), hohmannTransferTime / 2) / KerbalTime.secondsPerDay();
-      maxDays = minDays + Math.min(2 * destination.orbit.period(), hohmannTransferTime) / KerbalTime.secondsPerDay();
+      minDays = Math.max(minHohmannTransferTime - destination.orbit.period(), minHohmannTransferTime / 2) / KerbalTime.secondsPerDay();
+      maxDays = Math.max(maxHohmannTransferTime - destination.orbit.period(), maxHohmannTransferTime / 2) / KerbalTime.secondsPerDay() + Math.min(2 * destination.orbit.period(), maxHohmannTransferTime) / KerbalTime.secondsPerDay();
       minDays = minDays < 10 ? minDays.toFixed(2) : minDays.toFixed();
       maxDays = maxDays < 10 ? maxDays.toFixed(2) : maxDays.toFixed();
       $('#latestDepartureYear').val((maxDeparture / KerbalTime.daysPerYear | 0) + 1);

--- a/src/missionform.coffee
+++ b/src/missionform.coffee
@@ -252,8 +252,17 @@ class MissionForm
     origin = @origin()
     destination = @destination()
     referenceBody = origin.orbit.referenceBody
-    hohmannTransfer = Orbit.fromApoapsisAndPeriapsis(referenceBody, destination.orbit.semiMajorAxis, origin.orbit.semiMajorAxis, 0, 0, 0, 0)
-    hohmannTransferTime = hohmannTransfer.period() / 2
+    originPeriapsis = origin.orbit.periapsis()
+    originApopsis = origin.orbit.apoapsis()
+    destinationPeriapsis = destination.orbit.periapsis()
+    destinationApoapsis = destination.orbit.apoapsis()
+    if destinationPeriapsis <= originApopsis && originPeriapsis <= destinationApoapsis
+      # The orbits potentially overlap, so no lower limit on transfer time
+      minHohmannTransferTime = 0;
+    else
+      minHohmannTransferTime = Orbit.fromApoapsisAndPeriapsis(referenceBody, destinationPeriapsis, originPeriapsis, 0, 0, 0, 0).period() / 2;
+    maxHohmannTransferTime = Orbit.fromApoapsisAndPeriapsis(referenceBody, destinationApoapsis, originApopsis, 0, 0, 0, 0).period() / 2;
+        
     synodicPeriod = Math.abs(1 / (1 / destination.orbit.period() - 1 / origin.orbit.period()))
   
     departureRange = Math.min(2 * synodicPeriod, 2 * origin.orbit.period()) / KerbalTime.secondsPerDay()
@@ -266,8 +275,9 @@ class MissionForm
     minDeparture = KerbalTime.fromDate($('#earliestDepartureYear').val(), $('#earliestDepartureDay').val()).t / KerbalTime.secondsPerDay()
     maxDeparture = minDeparture + departureRange
   
-    minDays = Math.max(hohmannTransferTime - destination.orbit.period(), hohmannTransferTime / 2) / KerbalTime.secondsPerDay()
-    maxDays = minDays + Math.min(2 * destination.orbit.period(), hohmannTransferTime) / KerbalTime.secondsPerDay()
+    minDays = Math.max(minHohmannTransferTime - destination.orbit.period(), minHohmannTransferTime / 2) / KerbalTime.secondsPerDay()
+    maxDays = Math.max(maxHohmannTransferTime - destination.orbit.period(), maxHohmannTransferTime / 2) / KerbalTime.secondsPerDay() + 
+                Math.min(2 * destination.orbit.period(), maxHohmannTransferTime) / KerbalTime.secondsPerDay();
     minDays = if minDays < 10 then minDays.toFixed(2) else minDays.toFixed()
     maxDays = if maxDays < 10 then maxDays.toFixed(2) else maxDays.toFixed()
   


### PR DESCRIPTION
First of all, let me say this is a great tool! Thanks for making it!

I was using it with custom vessels in Kerbol orbit to find the best burn to get a planetary fly-by, and I found that sometimes the best burn would actually be a shorter transit time than what the default plot shows. The pork chop was completely correct, but the axes didn't include the best burn.  I know the "Time of flight" range can be adjusted in the advanced settings, but I was curious why the default range was wrong.

The default values for the y-axis range were being generated using the Hohmann transfer time as a guide.  However the Hohmann transfer time was calculated only using semi-major axis lengths of the two orbits.  But for eccentric orbits the Hohmann transfer time could be quite a bit less.  In fact, sometimes the origin orbit can overlap with the destination orbit (obviously this can only happen for custom vessel orbits), meaning there's no lower bound on transit time. There might even be an intercept/collision in the future with 0m/s of burn.

For journeys between planets and moons the y-axis range is only very slightly changed by this commit, due to low eccentricity of planet/moon orbits.  The difference only comes in for vessel orbits.  I have the modified version hosted at [https://andyborrell.github.io/ksp](https://andyborrell.github.io/ksp) if you would like to test.

See here for an example of a mission profile which has a better default range with this change: [https://imgur.com/a/WinrhOC](https://imgur.com/a/WinrhOC)